### PR TITLE
Events through repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,10 @@ mutate_actor_like:
 		--require project_management \
 		--use minitest "ProjectManagement*"
 
-test: test_aggregate_root test_query_based test_extracted_state test_functional test_polymorphic test_duck_typing test_yield_based test_actor_like
+test_repository:
+	@bundle exec ruby -Itest -Irepository -rproject_management test/issue_test.rb
+
+test: test_aggregate_root test_query_based test_extracted_state test_functional test_polymorphic test_duck_typing test_yield_based test_actor_like test_repository_like
 
 mutate: mutate_aggregate_root mutate_query_based mutate_extracted_state mutate_functional mutate_polymorphic mutate_duck_typing mutate_yield_based mutate_actor_like
 

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,6 @@ mutate_repository:
 
 test: test_aggregate_root test_query_based test_extracted_state test_functional test_polymorphic test_duck_typing test_yield_based test_actor_like test_repository_like
 
-mutate: mutate_aggregate_root mutate_query_based mutate_extracted_state mutate_functional mutate_polymorphic mutate_duck_typing mutate_yield_based mutate_actor_like
+mutate: mutate_aggregate_root mutate_query_based mutate_extracted_state mutate_functional mutate_polymorphic mutate_duck_typing mutate_yield_based mutate_actor_like mutate_repository
 
 .PHONY: test mutate

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,12 @@ mutate_actor_like:
 test_repository:
 	@bundle exec ruby -Itest -Irepository -rproject_management test/issue_test.rb
 
+mutate_repository:
+	@bundle exec mutant --include test \
+		--include repository\
+		--require project_management \
+		--use minitest "ProjectManagement*"
+
 test: test_aggregate_root test_query_based test_extracted_state test_functional test_polymorphic test_duck_typing test_yield_based test_actor_like test_repository_like
 
 mutate: mutate_aggregate_root mutate_query_based mutate_extracted_state mutate_functional mutate_polymorphic mutate_duck_typing mutate_yield_based mutate_actor_like

--- a/README.md
+++ b/README.md
@@ -66,3 +66,14 @@ More: https://blog.arkency.com/make-your-ruby-code-more-modular-and-functional-w
 
 - yield is used to publish events (no unpublished_events in aggregate)
 - aggregate repository separated from logic
+
+### Aggregate with repository
+
+[source](repository)
+
+- aggregate is unware of infrastructure
+- aggregate can built itself from events (but it could be recreated in any way)
+- aggregate keeps the state
+- aggregate registers events aka changes
+- aggregate provides API to read registered events
+- Infrastructure (through repository in this case) is responsible for building/saving the aggregate so it could be done in any way - Event Sourcing, serialization etc

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ More: https://blog.arkency.com/make-your-ruby-code-more-modular-and-functional-w
 
 - aggregate is unware of infrastructure
 - aggregate can built itself from events (but it could be recreated in any way)
-- aggregate keeps the state
+- aggregate keeps the state in PORO way
 - aggregate registers events aka changes
 - aggregate provides API to read registered events
 - Infrastructure (through repository in this case) is responsible for building/saving the aggregate so it could be done in any way - Event Sourcing, serialization etc

--- a/repository/project_management.rb
+++ b/repository/project_management.rb
@@ -1,0 +1,4 @@
+require_relative '../lib/project_management'
+require_relative 'project_management/repository'
+require_relative 'project_management/issue'
+require_relative 'project_management/command_handler'

--- a/repository/project_management/command_handler.rb
+++ b/repository/project_management/command_handler.rb
@@ -5,39 +5,27 @@ module ProjectManagement
     end
 
     def create(cmd)
-      with_aggregate(cmd.id) do |issue|
-        issue.create
-      end
+      with_aggregate(cmd.id, &:create)
     end
 
     def resolve(cmd)
-      with_aggregate(cmd.id) do |issue|
-        issue.resolve
-      end
+      with_aggregate(cmd.id, &:resolve)
     end
 
     def close(cmd)
-      with_aggregate(cmd.id) do |issue|
-        issue.close
-      end
+      with_aggregate(cmd.id, &:close)
     end
 
     def reopen(cmd)
-      with_aggregate(cmd.id) do |issue|
-        issue.reopen
-      end
+      with_aggregate(cmd.id, &:reopen)
     end
 
     def start(cmd)
-      with_aggregate(cmd.id) do |issue|
-        issue.start
-      end
+      with_aggregate(cmd.id, &:start)
     end
 
     def stop(cmd)
-      with_aggregate(cmd.id) do |issue|
-        issue.stop
-      end
+      with_aggregate(cmd.id, &:stop)
     end
 
     private
@@ -45,9 +33,10 @@ module ProjectManagement
     attr_reader :repository
 
     def with_aggregate(id)
-      issue, version = repository.load(id)
+      events, current_version = repository.load(id)
+      issue = Issue.load(id, events)
       yield issue
-      repository.save(issue, version)
+      repository.save(id, current_version, issue.changes)
     end
   end
 end

--- a/repository/project_management/command_handler.rb
+++ b/repository/project_management/command_handler.rb
@@ -1,0 +1,53 @@
+module ProjectManagement
+  class CommandHandler
+    def initialize(event_store)
+      @repository = Repository.new(event_store)
+    end
+
+    def create(cmd)
+      with_aggregate(cmd.id) do |issue|
+        issue.create
+      end
+    end
+
+    def resolve(cmd)
+      with_aggregate(cmd.id) do |issue|
+        issue.resolve
+      end
+    end
+
+    def close(cmd)
+      with_aggregate(cmd.id) do |issue|
+        issue.close
+      end
+    end
+
+    def reopen(cmd)
+      with_aggregate(cmd.id) do |issue|
+        issue.reopen
+      end
+    end
+
+    def start(cmd)
+      with_aggregate(cmd.id) do |issue|
+        issue.start
+      end
+    end
+
+    def stop(cmd)
+      with_aggregate(cmd.id) do |issue|
+        issue.stop
+      end
+    end
+
+    private
+
+    attr_reader :repository
+
+    def with_aggregate(id)
+      issue, version = repository.load(id)
+      yield issue
+      repository.save(issue, version)
+    end
+  end
+end

--- a/repository/project_management/issue.rb
+++ b/repository/project_management/issue.rb
@@ -1,0 +1,119 @@
+module ProjectManagement
+  class Issue
+    InvalidTransition = Class.new(StandardError)
+
+    attr_reader :id
+    attr_reader :events
+
+    def initialize(id)
+      @id = id
+      @events = []
+    end
+
+    def clear_events
+      @events = []
+    end
+
+    def create
+      invalid_transition unless can_create?
+
+      @status = :open
+
+      register_event(IssueOpened.new(data: { issue_id: @id }))
+    end
+
+    def resolve
+      invalid_transition unless can_resolve?
+
+      @status = :resolved
+
+      register_event(IssueResolved.new(data: { issue_id: @id }))
+    end
+
+    def close
+      invalid_transition unless can_close?
+
+      @status = :closed
+
+      register_event(IssueClosed.new(data: { issue_id: @id }))
+    end
+
+    def reopen
+      invalid_transition unless can_reopen?
+
+      @status = :reopened
+
+      register_event(IssueReopened.new(data: { issue_id: @id }))
+    end
+
+    def start
+      invalid_transition unless can_start?
+
+      @status = :in_progress
+
+      register_event(IssueProgressStarted.new(data: { issue_id: @id }))
+    end
+
+    def stop
+      invalid_transition unless can_stop?
+
+      @status = :open
+
+      register_event(IssueProgressStopped.new(data: { issue_id: @id }))
+    end
+
+    private
+
+    def register_event(event)
+      @events << event
+    end
+
+    def invalid_transition
+      raise InvalidTransition
+    end
+
+    def open?
+      @status.equal? :open
+    end
+
+    def closed?
+      @status.equal? :closed
+    end
+
+    def in_progress?
+      @status.equal? :in_progress
+    end
+
+    def reopened?
+      @status.equal? :reopened
+    end
+
+    def resolved?
+      @status.equal? :resolved
+    end
+
+    def can_reopen?
+      closed? || resolved?
+    end
+
+    def can_start?
+      open? || reopened?
+    end
+
+    def can_stop?
+      in_progress?
+    end
+
+    def can_close?
+      open? || in_progress? || reopened? || resolved?
+    end
+
+    def can_resolve?
+      open? || reopened? || in_progress?
+    end
+
+    def can_create?
+      !open?
+    end
+  end
+end

--- a/repository/project_management/issue.rb
+++ b/repository/project_management/issue.rb
@@ -2,16 +2,23 @@ module ProjectManagement
   class Issue
     InvalidTransition = Class.new(StandardError)
 
-    attr_reader :id
-    attr_reader :events
+    attr_reader :changes
+
+    def self.load(id, events)
+      issue = new(id)
+      issue.load(events)
+    end
 
     def initialize(id)
       @id = id
-      @events = []
+      @changes = []
     end
 
-    def clear_events
-      @events = []
+    def load(events)
+      events.each { |ev| on(ev) }
+      clear_changes
+
+      self
     end
 
     def create
@@ -65,7 +72,7 @@ module ProjectManagement
     private
 
     def register_event(event)
-      @events << event
+      changes << event
     end
 
     def invalid_transition
@@ -114,6 +121,30 @@ module ProjectManagement
 
     def can_create?
       !open?
+    end
+
+
+    private
+
+    def clear_changes
+      @changes = []
+    end
+
+    def on(event)
+      case event
+      when IssueOpened
+        create
+      when IssueResolved
+        resolve
+      when IssueClosed
+        close
+      when IssueReopened
+        reopen
+      when IssueProgressStarted
+        start
+      when IssueProgressStopped
+        stop
+      end
     end
   end
 end

--- a/repository/project_management/issue.rb
+++ b/repository/project_management/issue.rb
@@ -123,9 +123,6 @@ module ProjectManagement
       !open?
     end
 
-
-    private
-
     def clear_changes
       @changes = []
     end

--- a/repository/project_management/repository.rb
+++ b/repository/project_management/repository.rb
@@ -1,4 +1,3 @@
-require 'pry'
 module ProjectManagement
   class Repository
     def initialize(event_store)
@@ -6,48 +5,21 @@ module ProjectManagement
     end
 
     def load(id)
-      issue = Issue.new(id)
+      events = store.read.stream(stream_name(id)).to_a
+      version = events.size - 1
 
-      store.read.stream(stream_name(id)).each do |event|
-        build_state(issue, event)
-      end
-
-      version = issue.events.size - 1
-
-      issue.clear_events
-
-      [issue, version]
+      [events, version]
     end
 
-    def save(issue, current_version)
-      issue.events.each.with_index do |event, index|
-        store.publish(event, stream_name: stream_name(issue.id), expected_version: current_version + index)
+    def save(id, current_version, changes)
+      changes.each.with_index(current_version) do |event, index|
+        store.publish(event, stream_name: stream_name(id), expected_version: index)
       end
-      issue.clear_events
     end
 
     private
 
     attr_reader :store
-
-    def build_state(issue, event)
-      case event
-      when IssueOpened
-        issue.create
-      when IssueResolved
-        issue.resolve
-      when IssueClosed
-        issue.close
-      when IssueReopened
-        issue.reopen
-      when IssueProgressStarted
-        issue.start
-      when IssueProgressStopped
-        issue.stop
-      else
-        raise 'event not implemented'
-      end
-    end
 
     def stream_name(id)
       "Issue$#{id}"

--- a/repository/project_management/repository.rb
+++ b/repository/project_management/repository.rb
@@ -12,9 +12,11 @@ module ProjectManagement
     end
 
     def save(id, current_version, changes)
-      changes.each.with_index(current_version) do |event, index|
-        store.publish(event, stream_name: stream_name(id), expected_version: index)
-      end
+      store.publish(
+        changes,
+        stream_name: stream_name(id),
+        expected_version: current_version
+      )
     end
 
     private

--- a/repository/project_management/repository.rb
+++ b/repository/project_management/repository.rb
@@ -1,0 +1,56 @@
+require 'pry'
+module ProjectManagement
+  class Repository
+    def initialize(event_store)
+      @store = event_store
+    end
+
+    def load(id)
+      issue = Issue.new(id)
+
+      store.read.stream(stream_name(id)).each do |event|
+        build_state(issue, event)
+      end
+
+      version = issue.events.size - 1
+
+      issue.clear_events
+
+      [issue, version]
+    end
+
+    def save(issue, current_version)
+      issue.events.each.with_index do |event, index|
+        store.publish(event, stream_name: stream_name(issue.id), expected_version: current_version + index)
+      end
+      issue.clear_events
+    end
+
+    private
+
+    attr_reader :store
+
+    def build_state(issue, event)
+      case event
+      when IssueOpened
+        issue.create
+      when IssueResolved
+        issue.resolve
+      when IssueClosed
+        issue.close
+      when IssueReopened
+        issue.reopen
+      when IssueProgressStarted
+        issue.start
+      when IssueProgressStopped
+        issue.stop
+      else
+        raise 'event not implemented'
+      end
+    end
+
+    def stream_name(id)
+      "Issue$#{id}"
+    end
+  end
+end


### PR DESCRIPTION
I'm not sure if this should be called `repository` or something else but the main goal is like stated in the readme:

- aggregate is unware of infrastructure
- aggregate can built itself from events (but it could be recreated in any way in case that you don't want event sourcing but still have events and similar structure)
- aggregate keeps the state
- aggregate registers events aka changes
- aggregate provides API to read registered events
- Infrastructure (through repository in this case) is responsible for building/saving the aggregate so it could be done in any way - Event Sourcing, serialization etc

Inspired partly by https://paucls.wordpress.com/2018/05/31/ddd-aggregate-roots-and-domain-events-publication/ and appendix A to Vernon's book.